### PR TITLE
Remove -fpic from Windows CUDA issue with the build for ipc-toolkit with vcpkg on Windows 

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,9 +1,11 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
+  
 
 env:
   CTEST_OUTPUT_ON_FAILURE: ON

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,11 +1,9 @@
 name: Build
 
 on:
-  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
-  
 
 env:
   CTEST_OUTPUT_ON_FAILURE: ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,11 +166,9 @@ if(SCALABLE_CCD_WITH_CUDA)
   endif()
 
   # We need to explicitly state that we need all CUDA files in the particle
-  # Enable separable compilation for CUDA
   # library to be built with -dc as the member functions could be called by
   # other libraries and executables.
-  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-  set_target_properties(scalable_ccd PROPERTIES CUDA_SEPARABLE_COMPILATION ON POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(scalable_ccd PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
   
   if(DEFINED SCALABLE_CCD_CUDA_ARCHITECTURES)
     message(STATUS "CUDA_ARCHITECTURES was specified, skipping auto-detection")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,11 +165,13 @@ if(SCALABLE_CCD_WITH_CUDA)
     message(FATAL_ERROR "No CUDA support found!")
   endif()
 
-  # We need to explicitly state that we need all CUDA files in the particle
-  # library to be built with -dc as the member functions could be called by
-  # other libraries and executables.
+  # Enable separable compilation for CUDA
   set_target_properties(scalable_ccd PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
+  # We need to explicitly state that we need all CUDA files in the particle
+  # Enable separable compilation for CUDA
+  # library to be built with -dc as the member functions could be called by
+  # other libraries and executables.
   if(DEFINED SCALABLE_CCD_CUDA_ARCHITECTURES)
     message(STATUS "CUDA_ARCHITECTURES was specified, skipping auto-detection")
     set(CMAKE_CUDA_ARCHITECTURES ${SCALABLE_CCD_CUDA_ARCHITECTURES})
@@ -189,21 +191,34 @@ if(SCALABLE_CCD_WITH_CUDA)
 
   if(APPLE)
     # We need to add the path to the driver (libcuda.dylib) as an rpath,
+    # Add rpath for CUDA on macOS
     # so that the static cuda runtime can find it at runtime.
     set_property(TARGET scalable_ccd
       PROPERTY
       BUILD_RPATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
   endif()
 
-  target_compile_options(scalable_ccd PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
-    --generate-line-info
-    --use_fast_math
-    --relocatable-device-code=true
-
-    # --ptxas-options=-v
-    # --maxrregcount=7
-    -fPIC # https://stackoverflow.com/questions/5311515/gcc-fpic-option
-    >)
+  # Conditionally add CUDA compile options based on the platform
+  if(WIN32)
+    target_compile_options(scalable_ccd PRIVATE 
+      $<$<COMPILE_LANGUAGE:CUDA>:
+        --generate-line-info
+        --use_fast_math
+        --relocatable-device-code=true
+      >
+    )
+  else()
+    target_compile_options(scalable_ccd PRIVATE 
+      $<$<COMPILE_LANGUAGE:CUDA>:
+        --generate-line-info
+        --use_fast_math
+        --relocatable-device-code=true
+        # --ptxas-options=-v
+        # --maxrregcount=7
+        -fPIC # https://stackoverflow.com/questions/5311515/gcc-fpic-option
+      >
+    )
+  endif()
 
   find_package(CUDAToolkit)
   target_link_libraries(scalable_ccd PUBLIC CUDA::cudart)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,13 +165,13 @@ if(SCALABLE_CCD_WITH_CUDA)
     message(FATAL_ERROR "No CUDA support found!")
   endif()
 
-  # Enable separable compilation for CUDA
-  set_target_properties(scalable_ccd PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-
   # We need to explicitly state that we need all CUDA files in the particle
   # Enable separable compilation for CUDA
   # library to be built with -dc as the member functions could be called by
   # other libraries and executables.
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(scalable_ccd PROPERTIES CUDA_SEPARABLE_COMPILATION ON POSITION_INDEPENDENT_CODE ON)
+  
   if(DEFINED SCALABLE_CCD_CUDA_ARCHITECTURES)
     message(STATUS "CUDA_ARCHITECTURES was specified, skipping auto-detection")
     set(CMAKE_CUDA_ARCHITECTURES ${SCALABLE_CCD_CUDA_ARCHITECTURES})
@@ -191,34 +191,19 @@ if(SCALABLE_CCD_WITH_CUDA)
 
   if(APPLE)
     # We need to add the path to the driver (libcuda.dylib) as an rpath,
-    # Add rpath for CUDA on macOS
     # so that the static cuda runtime can find it at runtime.
     set_property(TARGET scalable_ccd
       PROPERTY
       BUILD_RPATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
   endif()
 
-  # Conditionally add CUDA compile options based on the platform
-  if(WIN32)
-    target_compile_options(scalable_ccd PRIVATE 
-      $<$<COMPILE_LANGUAGE:CUDA>:
-        --generate-line-info
-        --use_fast_math
-        --relocatable-device-code=true
-      >
-    )
-  else()
-    target_compile_options(scalable_ccd PRIVATE 
-      $<$<COMPILE_LANGUAGE:CUDA>:
-        --generate-line-info
-        --use_fast_math
-        --relocatable-device-code=true
-        # --ptxas-options=-v
-        # --maxrregcount=7
-        -fPIC # https://stackoverflow.com/questions/5311515/gcc-fpic-option
-      >
-    )
-  endif()
+  target_compile_options(scalable_ccd PRIVATE 
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --generate-line-info
+      --use_fast_math
+      --relocatable-device-code=true
+    >
+  )
 
   find_package(CUDAToolkit)
   target_link_libraries(scalable_ccd PUBLIC CUDA::cudart)


### PR DESCRIPTION
-- Building for: Visual Studio 17 2022
-- Selecting Windows SDK version 10.0.22621.0 to target Windows 10.0.22631.
-- The CXX compiler identification is MSVC 19.41.34120.0
-- Looking for a CUDA compiler
-- Looking for a CUDA compiler - C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6/bin/nvcc.exe
-- The CUDA compiler identification is NVIDIA 12.6.68

![image](https://github.com/user-attachments/assets/895f05f9-720b-4d44-a1ca-ca8a47d2723b)
