### PR TITLE
Fix MSVC + CUDA 13.3 build and bump dependencies

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -159,10 +159,10 @@ jobs:
         with:
           arch: x64
 
-      - uses: Jimver/cuda-toolkit@v0.2.22
+      - uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
         with:
-          cuda: '12.8.1'
+          cuda: '13.2.0'
           sub-packages: '["nvcc"]'
           method: 'network'
 

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -115,19 +115,21 @@ jobs:
       - name: Tests
         run: cd build; ctest --verbose -j ${{ steps.cpu-cores.outputs.count }}
 
-  build_cuda: # no runtime support for CUDA, so only build on Linux
+  build_cuda: # CI runners have no GPU, so these jobs build only (no tests)
     name: ${{ matrix.name }} CUDA (${{ matrix.config }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         config:
           - Debug
           # - Release # cannot run multiple cuda-toolkit jobs in parallel
         include:
           - os: ubuntu-latest
             name: Linux
+          - os: windows-latest
+            name: Windows
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.0.0
@@ -139,6 +141,23 @@ jobs:
         run: |
           sudo apt-get install ccache
           echo 'CACHE_PATH=~/.cache/ccache' >> "$GITHUB_ENV"
+
+      - name: Dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install ccache
+          "CACHE_PATH=${env:LOCALAPPDATA}\ccache" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      # Ninja + MSVC are needed to drive nvcc's host compiler on Windows.
+      - name: Install Ninja
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Setup MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
 
       - uses: Jimver/cuda-toolkit@v0.2.22
         id: cuda-toolkit
@@ -164,7 +183,8 @@ jobs:
           ccache -V && ccache --show-config
           ccache --show-stats && ccache --zero-stats
 
-      - name: Configure
+      - name: Configure (Linux)
+        if: runner.os == 'Linux'
         run: |
           mkdir -p build
           cd build
@@ -173,6 +193,18 @@ jobs:
             -DSCALABLE_CCD_CUDA_ARCHITECTURES=75 \
             -DSCALABLE_CCD_BUILD_TESTS=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          cmake -G Ninja ^
+            -DSCALABLE_CCD_WITH_CUDA=ON ^
+            -DSCALABLE_CCD_CUDA_ARCHITECTURES=75 ^
+            -DSCALABLE_CCD_BUILD_TESTS=ON ^
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
+            -B build ^
+            -S .
 
       - name: Build
         run: |

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -128,8 +128,12 @@ jobs:
         include:
           - os: ubuntu-latest
             name: Linux
+            cuda_subpackages: '["nvcc"]'
           - os: windows-latest
             name: Windows
+            # Windows components are split finer than Linux: nvcc alone lacks
+            # the runtime headers (cuda_runtime.h) and thrust/cub, so list them.
+            cuda_subpackages: '["nvcc", "cudart", "thrust", "cub", "cccl"]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.0.0
@@ -163,7 +167,7 @@ jobs:
         id: cuda-toolkit
         with:
           cuda: '13.2.0'
-          sub-packages: '["nvcc"]'
+          sub-packages: ${{ matrix.cuda_subpackages }}
           method: 'network'
 
       # The action sets CUDA_PATH but, combined with msvc-dev-cmd re-exporting
@@ -175,7 +179,10 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           Write-Host "CUDA_PATH = $env:CUDA_PATH"
+          Write-Host "--- bin ---"
           Get-ChildItem "$env:CUDA_PATH\bin" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+          Write-Host "--- include (top level) ---"
+          Get-ChildItem "$env:CUDA_PATH\include" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
           $nvcc = "$env:CUDA_PATH\bin\nvcc.exe"
           if (-not (Test-Path $nvcc)) { throw "nvcc.exe not found at $nvcc" }
           "$env:CUDA_PATH\bin" | Out-File -FilePath $env:GITHUB_PATH -Append

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CTEST_OUTPUT_ON_FAILURE: ON
   CTEST_PARALLEL_LEVEL: 2
@@ -27,7 +31,7 @@ jobs:
             name: Windows
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v6
         with:
           fetch-depth: 10
 
@@ -54,13 +58,19 @@ jobs:
         if: runner.os == 'Windows'
         uses: seanmiddleditch/gha-setup-ninja@master
 
+      - name: Setup MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v2.0.0
+        uses: SimenB/github-actions-cpu-cores@v2
         id: cpu-cores
 
       - name: Cache Build
         id: cache-build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.CACHE_PATH }}
           key: ${{ runner.os }}-${{ matrix.config }}-cache
@@ -84,7 +94,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64
           cmake -G Ninja ^
             -DSCALABLE_CCD_BUILD_TESTS=ON ^
             -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
@@ -101,7 +110,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64
           cmake --build build -j ${{ steps.cpu-cores.outputs.count }} && ccache --show-stats
 
       - name: Tests

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -133,11 +133,13 @@ jobs:
             name: Windows
             # Windows splits the toolkit into finer components than Linux and an
             # invalid component name aborts the whole install, so name exactly
-            # what the build needs: nvcc (compiler), cudart (cuda_runtime.h),
-            # crt (crt/host_config.h), cccl (thrust/cub/libcudacxx; the separate
-            # thrust/cub components were removed in CUDA 13). These map to the
-            # redist components cuda_{nvcc,cudart,crt,cccl} minus the cuda_ prefix.
-            cuda_subpackages: '["nvcc", "cudart", "crt", "cccl"]'
+            # what the build needs (per the Windows installer subpackage list):
+            #   nvcc   - compiler
+            #   cudart - cuda_runtime.h + runtime library
+            #   crt    - crt/host_config.h
+            #   thrust - Thrust, and the CUB/libcudacxx headers it bundles
+            # ("cccl"/"cub" are not valid Windows installer subpackage names.)
+            cuda_subpackages: '["nvcc", "cudart", "crt", "thrust"]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.0.0

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -143,7 +143,7 @@ jobs:
             cuda_subpackages: '["nvcc", "nvvm", "cudart", "crt", "thrust"]'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v6
         with:
           fetch-depth: 10
 
@@ -168,7 +168,8 @@ jobs:
       # (check_language(CUDA) still does not reliably autodetect nvcc on this
       # runner even with it on PATH, so the Windows configure also passes
       # -DCMAKE_CUDA_COMPILER explicitly.)
-      - uses: Jimver/cuda-toolkit@v0.2.35
+      - name: Install CUDA Toolkit
+        uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
         with:
           cuda: '13.2.0'
@@ -182,12 +183,12 @@ jobs:
           arch: x64
 
       - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v2.0.0
+        uses: SimenB/github-actions-cpu-cores@v2
         id: cpu-cores
 
       - name: Cache Build
         id: cache-build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.CACHE_PATH }}
           key: ${{ runner.os }}-${{ matrix.config }}-CUDA-cache

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -131,9 +131,12 @@ jobs:
             cuda_subpackages: '["nvcc"]'
           - os: windows-latest
             name: Windows
-            # Windows components are split finer than Linux: nvcc alone lacks
-            # the runtime headers (cuda_runtime.h) and thrust/cub, so list them.
-            cuda_subpackages: '["nvcc", "cudart", "thrust", "cub", "cccl"]'
+            # Windows splits the toolkit finer than Linux: nvcc alone lacks the
+            # runtime headers (cuda_runtime.h). cudart adds them. (An invalid
+            # component name aborts the whole install, so keep this to names
+            # known to exist for this CUDA version; the include/ listing in the
+            # "Locate CUDA compiler" step shows what actually landed.)
+            cuda_subpackages: '["nvcc", "cudart"]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.0.0

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -128,21 +128,16 @@ jobs:
         include:
           - os: ubuntu-latest
             name: Linux
-            # Linux sub-package filtering requires the 'network' method.
-            cuda_method: 'network'
             cuda_subpackages: '["nvcc"]'
           - os: windows-latest
             name: Windows
-            # Windows splits the toolkit into many fine-grained components whose
-            # headers depend on each other (nvcc -> cudart -> crt -> thrust/cub
-            # ...), and an invalid component name aborts the whole install. Rather
-            # than enumerate them, install the full toolkit: the 'local' method
-            # with an empty sub-package list installs everything. Slower to
-            # install, but guaranteed to have every header. (The 'network' method
-            # only fetches the packages named in sub-packages, so it cannot do a
-            # full install.)
-            cuda_method: 'local'
-            cuda_subpackages: '[]'
+            # Windows splits the toolkit into finer components than Linux and an
+            # invalid component name aborts the whole install, so name exactly
+            # what the build needs: nvcc (compiler), cudart (cuda_runtime.h),
+            # crt (crt/host_config.h), cccl (thrust/cub/libcudacxx; the separate
+            # thrust/cub components were removed in CUDA 13). These map to the
+            # redist components cuda_{nvcc,cudart,crt,cccl} minus the cuda_ prefix.
+            cuda_subpackages: '["nvcc", "cudart", "crt", "cccl"]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.0.0
@@ -174,7 +169,7 @@ jobs:
         with:
           cuda: '13.2.0'
           sub-packages: ${{ matrix.cuda_subpackages }}
-          method: ${{ matrix.cuda_method }}
+          method: 'network'
 
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -166,12 +166,16 @@ jobs:
           sub-packages: '["nvcc"]'
           method: 'network'
 
-      # On Windows the action sets CUDA_PATH but does not add nvcc to PATH, so
-      # CMake's check_language(CUDA) can't find the compiler. Add it explicitly.
-      - name: Add CUDA to PATH (Windows)
+      # The action sets CUDA_PATH but, combined with msvc-dev-cmd re-exporting
+      # PATH, nvcc does not reliably land on PATH for CMake's
+      # check_language(CUDA). Point CMake at nvcc directly via CUDACXX (honored
+      # before any PATH search) and add it to PATH for good measure.
+      - name: Locate CUDA compiler (Windows)
         if: runner.os == 'Windows'
         run: |
           "$env:CUDA_PATH\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+          $nvcc = "$env:CUDA_PATH\bin\nvcc.exe" -replace '\\', '/'
+          "CUDACXX=$nvcc" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v2.0.0

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -168,14 +168,18 @@ jobs:
 
       # The action sets CUDA_PATH but, combined with msvc-dev-cmd re-exporting
       # PATH, nvcc does not reliably land on PATH for CMake's
-      # check_language(CUDA). Point CMake at nvcc directly via CUDACXX (honored
-      # before any PATH search) and add it to PATH for good measure.
+      # check_language(CUDA). Point CMake at nvcc directly (passed to cmake as
+      # -DCMAKE_CUDA_COMPILER below) and add it to PATH for good measure.
+      # Also verify the install actually produced nvcc.exe.
       - name: Locate CUDA compiler (Windows)
         if: runner.os == 'Windows'
         run: |
+          Write-Host "CUDA_PATH = $env:CUDA_PATH"
+          Get-ChildItem "$env:CUDA_PATH\bin" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+          $nvcc = "$env:CUDA_PATH\bin\nvcc.exe"
+          if (-not (Test-Path $nvcc)) { throw "nvcc.exe not found at $nvcc" }
           "$env:CUDA_PATH\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
-          $nvcc = "$env:CUDA_PATH\bin\nvcc.exe" -replace '\\', '/'
-          "CUDACXX=$nvcc" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "CUDACXX=$($nvcc -replace '\\', '/')" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v2.0.0
@@ -213,6 +217,7 @@ jobs:
             -DSCALABLE_CCD_WITH_CUDA=ON ^
             -DSCALABLE_CCD_CUDA_ARCHITECTURES=75 ^
             -DSCALABLE_CCD_BUILD_TESTS=ON ^
+            -DCMAKE_CUDA_COMPILER="%CUDA_PATH%\bin\nvcc.exe" ^
             -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
             -B build ^
             -S .

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -131,12 +131,12 @@ jobs:
             cuda_subpackages: '["nvcc"]'
           - os: windows-latest
             name: Windows
-            # Windows splits the toolkit finer than Linux: nvcc alone lacks the
-            # runtime headers (cuda_runtime.h). cudart adds them. (An invalid
-            # component name aborts the whole install, so keep this to names
-            # known to exist for this CUDA version; the include/ listing in the
-            # "Locate CUDA compiler" step shows what actually landed.)
-            cuda_subpackages: '["nvcc", "cudart"]'
+            # Windows splits the toolkit into many fine-grained components whose
+            # headers depend on each other (nvcc -> cudart -> crt -> thrust/cub
+            # ...), and an invalid component name aborts the whole install. Rather
+            # than enumerate them, install the full toolkit (empty list = no -s
+            # filter). Slower to install, but guaranteed to have every header.
+            cuda_subpackages: '[]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.0.0

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -134,12 +134,13 @@ jobs:
             # Windows splits the toolkit into finer components than Linux and an
             # invalid component name aborts the whole install, so name exactly
             # what the build needs (per the Windows installer subpackage list):
-            #   nvcc   - compiler
+            #   nvcc   - compiler front-end (nvcc, cudafe++, ptxas, nvlink)
+            #   nvvm   - device compiler backend (cicc); nvcc alone omits it
             #   cudart - cuda_runtime.h + runtime library
             #   crt    - crt/host_config.h
             #   thrust - Thrust, and the CUB/libcudacxx headers it bundles
             # ("cccl"/"cub" are not valid Windows installer subpackage names.)
-            cuda_subpackages: '["nvcc", "cudart", "crt", "thrust"]'
+            cuda_subpackages: '["nvcc", "nvvm", "cudart", "crt", "thrust"]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.0.0

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -128,14 +128,20 @@ jobs:
         include:
           - os: ubuntu-latest
             name: Linux
+            # Linux sub-package filtering requires the 'network' method.
+            cuda_method: 'network'
             cuda_subpackages: '["nvcc"]'
           - os: windows-latest
             name: Windows
             # Windows splits the toolkit into many fine-grained components whose
             # headers depend on each other (nvcc -> cudart -> crt -> thrust/cub
             # ...), and an invalid component name aborts the whole install. Rather
-            # than enumerate them, install the full toolkit (empty list = no -s
-            # filter). Slower to install, but guaranteed to have every header.
+            # than enumerate them, install the full toolkit: the 'local' method
+            # with an empty sub-package list installs everything. Slower to
+            # install, but guaranteed to have every header. (The 'network' method
+            # only fetches the packages named in sub-packages, so it cannot do a
+            # full install.)
+            cuda_method: 'local'
             cuda_subpackages: '[]'
     steps:
       - name: Checkout repository
@@ -171,7 +177,7 @@ jobs:
         with:
           cuda: '13.2.0'
           sub-packages: ${{ matrix.cuda_subpackages }}
-          method: 'network'
+          method: ${{ matrix.cuda_method }}
 
       # The action sets CUDA_PATH but, combined with msvc-dev-cmd re-exporting
       # PATH, nvcc does not reliably land on PATH for CMake's

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -166,6 +166,13 @@ jobs:
           sub-packages: '["nvcc"]'
           method: 'network'
 
+      # On Windows the action sets CUDA_PATH but does not add nvcc to PATH, so
+      # CMake's check_language(CUDA) can't find the compiler. Add it explicitly.
+      - name: Add CUDA to PATH (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          "$env:CUDA_PATH\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v2.0.0
         id: cpu-cores

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -161,17 +161,14 @@ jobs:
           choco install ccache
           "CACHE_PATH=${env:LOCALAPPDATA}\ccache" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      # Ninja + MSVC are needed to drive nvcc's host compiler on Windows.
       - name: Install Ninja
         if: runner.os == 'Windows'
         uses: seanmiddleditch/gha-setup-ninja@master
 
-      - name: Setup MSVC (Windows)
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-
+      # Install CUDA before msvc-dev-cmd: the toolkit adds its bin dir (nvcc) to
+      # PATH, and msvc-dev-cmd snapshots PATH into GITHUB_ENV for later steps, so
+      # it must run afterward for that snapshot to include nvcc. With nvcc on
+      # PATH, CMake's check_language(CUDA) finds it without further hints.
       - uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
         with:
@@ -179,23 +176,11 @@ jobs:
           sub-packages: ${{ matrix.cuda_subpackages }}
           method: ${{ matrix.cuda_method }}
 
-      # The action sets CUDA_PATH but, combined with msvc-dev-cmd re-exporting
-      # PATH, nvcc does not reliably land on PATH for CMake's
-      # check_language(CUDA). Point CMake at nvcc directly (passed to cmake as
-      # -DCMAKE_CUDA_COMPILER below) and add it to PATH for good measure.
-      # Also verify the install actually produced nvcc.exe.
-      - name: Locate CUDA compiler (Windows)
+      - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'
-        run: |
-          Write-Host "CUDA_PATH = $env:CUDA_PATH"
-          Write-Host "--- bin ---"
-          Get-ChildItem "$env:CUDA_PATH\bin" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
-          Write-Host "--- include (top level) ---"
-          Get-ChildItem "$env:CUDA_PATH\include" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
-          $nvcc = "$env:CUDA_PATH\bin\nvcc.exe"
-          if (-not (Test-Path $nvcc)) { throw "nvcc.exe not found at $nvcc" }
-          "$env:CUDA_PATH\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
-          "CUDACXX=$($nvcc -replace '\\', '/')" | Out-File -FilePath $env:GITHUB_ENV -Append
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
 
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v2.0.0
@@ -233,7 +218,6 @@ jobs:
             -DSCALABLE_CCD_WITH_CUDA=ON ^
             -DSCALABLE_CCD_CUDA_ARCHITECTURES=75 ^
             -DSCALABLE_CCD_BUILD_TESTS=ON ^
-            -DCMAKE_CUDA_COMPILER="%CUDA_PATH%\bin\nvcc.exe" ^
             -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
             -B build ^
             -S .

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -162,10 +162,11 @@ jobs:
         if: runner.os == 'Windows'
         uses: seanmiddleditch/gha-setup-ninja@master
 
-      # Install CUDA before msvc-dev-cmd: the toolkit adds its bin dir (nvcc) to
-      # PATH, and msvc-dev-cmd snapshots PATH into GITHUB_ENV for later steps, so
-      # it must run afterward for that snapshot to include nvcc. With nvcc on
-      # PATH, CMake's check_language(CUDA) finds it without further hints.
+      # Install CUDA before msvc-dev-cmd so the toolkit's bin dir lands on PATH
+      # before msvc-dev-cmd snapshots PATH into GITHUB_ENV for later steps.
+      # (check_language(CUDA) still does not reliably autodetect nvcc on this
+      # runner even with it on PATH, so the Windows configure also passes
+      # -DCMAKE_CUDA_COMPILER explicitly.)
       - uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
         with:
@@ -215,6 +216,7 @@ jobs:
             -DSCALABLE_CCD_WITH_CUDA=ON ^
             -DSCALABLE_CCD_CUDA_ARCHITECTURES=75 ^
             -DSCALABLE_CCD_BUILD_TESTS=ON ^
+            -DCMAKE_CUDA_COMPILER="%CUDA_PATH%\bin\nvcc.exe" ^
             -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
             -B build ^
             -S .

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ bin*
 .idea/
 *.code-workspace
 *.vscode
+*.vs
 
 ## python
 # Byte-compiled / optimized / DLL files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,27 @@ if(SCALABLE_CCD_WITH_CUDA)
     set_property(TARGET scalable_ccd
       PROPERTY
       BUILD_RPATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+  elseif(MSVC)
+    # MSVC host-compiler flags required to compile scalable_ccd's CUDA sources
+    # (and public *.cuh headers, hence PUBLIC so consumers such as the tests
+    # inherit them through the link graph, mirroring --expt-relaxed-constexpr).
+    #
+    #   * -Xcompiler=/Zc:preprocessor (CUDA): the .cu files include CCCL headers
+    #     (thrust/cub), whose <cuda/std/__cccl/preprocessor.h> emits a hard
+    #     #error unless the standard-conforming preprocessor is used. Forwarded
+    #     to the host compiler for the nvcc host pass.
+    #   * /Zc:preprocessor (CXX): defensive. No .cpp currently reaches CCCL, but
+    #     keep it so a future CXX TU that includes thrust/cub does not break.
+    #   * -Xcompiler=/utf-8 (CUDA): spdlog's bundled fmt needs a UTF-8 execution
+    #     charset. Our fmt patch forces is_utf8_enabled=1 under __CUDACC__ (the
+    #     front-end can't run fmt's compile-time probe); this flag makes that
+    #     assumption true for the host pass. CXX .cpp files get /utf-8
+    #     transitively from spdlog (it exports it PUBLIC for CXX/MSVC).
+    target_compile_options(scalable_ccd PUBLIC
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/utf-8>
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/Zc:preprocessor>
+        $<$<COMPILE_LANGUAGE:CXX>:/Zc:preprocessor>
+    )
   endif()
 
   target_compile_options(scalable_ccd PRIVATE

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,111 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 24
+  },
+  "configurePresets": [{
+      "name": "release",
+      "displayName": "Release Build",
+      "description": "Base preset for release builds",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_STANDARD": "17"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug Build",
+      "description": "Base preset for debug builds",
+      "binaryDir": "${sourceDir}/build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_STANDARD": "17"
+      }
+    },
+    {
+      "name": "default",
+      "inherits": "release",
+      "displayName": "Default Configuration",
+      "description": "Default build configuration",
+      "binaryDir": "${sourceDir}/build/default"
+    },
+    {
+      "name": "cuda-release",
+      "inherits": "release",
+      "displayName": "CUDA (Release)",
+      "description": "Release build with CUDA support",
+      "binaryDir": "${sourceDir}/build/cuda-release",
+      "cacheVariables": {
+        "SCALABLE_CCD_WITH_CUDA": "ON"
+      }
+    },
+    {
+      "name": "cuda-debug",
+      "inherits": "debug",
+      "displayName": "CUDA (Debug)",
+      "description": "Debug build with CUDA support",
+      "binaryDir": "${sourceDir}/build/cuda-debug",
+      "cacheVariables": {
+        "SCALABLE_CCD_WITH_CUDA": "ON"
+      }
+    }
+  ],
+  "buildPresets": [{
+      "name": "release",
+      "configurePreset": "release",
+      "displayName": "Release Build",
+      "description": "Base preset for release builds"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "displayName": "Debug Build",
+      "description": "Base preset for debug builds"
+    },
+    {
+      "name": "default-build",
+      "configurePreset": "default",
+      "displayName": "Default Configuration",
+      "description": "Build using default configuration"
+    },
+    {
+      "name": "cuda-release",
+      "configurePreset": "cuda-release",
+      "displayName": "CUDA (Release)",
+      "description": "Build with CUDA support"
+    },
+    {
+      "name": "cuda-debug",
+      "configurePreset": "cuda-debug",
+      "displayName": "CUDA (Debug)",
+      "description": "Debug build with CUDA support"
+    }
+  ],
+  "testPresets": [{
+      "name": "default-tests",
+      "description": "Run default tests",
+      "configurePreset": "test",
+      "execution": {
+        "stopOnFailure": true
+      }
+    },
+    {
+      "name": "cuda-tests-release",
+      "description": "Run tests with CUDA (Release) enabled",
+      "configurePreset": "cuda-release",
+      "execution": {
+        "stopOnFailure": true
+      }
+    },
+    {
+      "name": "cuda-tests-debug",
+      "description": "Run tests with CUDA (Debug) enabled",
+      "configurePreset": "cuda-debug",
+      "execution": {
+        "stopOnFailure": true
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -82,30 +82,5 @@
       "displayName": "CUDA (Debug)",
       "description": "Debug build with CUDA support"
     }
-  ],
-  "testPresets": [{
-      "name": "default-tests",
-      "description": "Run default tests",
-      "configurePreset": "test",
-      "execution": {
-        "stopOnFailure": true
-      }
-    },
-    {
-      "name": "cuda-tests-release",
-      "description": "Run tests with CUDA (Release) enabled",
-      "configurePreset": "cuda-release",
-      "execution": {
-        "stopOnFailure": true
-      }
-    },
-    {
-      "name": "cuda-tests-debug",
-      "description": "Run tests with CUDA (Debug) enabled",
-      "configurePreset": "cuda-debug",
-      "execution": {
-        "stopOnFailure": true
-      }
-    }
   ]
 }

--- a/cmake/patches/fmt-nvcc-compat.patch
+++ b/cmake/patches/fmt-nvcc-compat.patch
@@ -1,0 +1,42 @@
+diff --git a/include/spdlog/fmt/bundled/base.h b/include/spdlog/fmt/bundled/base.h
+index 620456b..0740975 100644
+--- a/include/spdlog/fmt/bundled/base.h
++++ b/include/spdlog/fmt/bundled/base.h
+@@ -455,7 +455,14 @@ struct is_std_string_like<T, void_t<decltype(std::declval<T>().find_first_of(
+                           const typename T::value_type*> {};
+ 
+ // Check if the literal encoding is UTF-8.
++#if defined(__CUDACC__)
++// NVCC's device front-end (EDG) does not honor the host compiler's /utf-8
++// flag, so the compile-time probe below misfires. The host pass is compiled
++// with /utf-8, so UTF-8 is in fact enabled.
++enum { is_utf8_enabled = 1 };
++#else
+ enum { is_utf8_enabled = "\u00A7"[1] == '\xA7' };
++#endif
+ enum { use_utf8 = !FMT_WIN32 || is_utf8_enabled };
+ 
+ #ifndef FMT_UNICODE
+diff --git a/include/spdlog/fmt/bundled/format.h b/include/spdlog/fmt/bundled/format.h
+index 4a65300..2ce9069 100644
+--- a/include/spdlog/fmt/bundled/format.h
++++ b/include/spdlog/fmt/bundled/format.h
+@@ -3138,8 +3138,18 @@ constexpr auto fractional_part_rounding_thresholds(int index) -> uint32_t {
+   // It is equal to ceil(2^31 + 2^32/10^(k + 1)).
+   // These are stored in a string literal because we cannot have static arrays
+   // in constexpr functions and non-static ones are poorly optimized.
++#if defined(__CUDACC__)
++  // NVCC's device front-end (EDG) rejects char32_t hex escapes whose value has
++  // the high bit set ("character value is out of range"), so use an equivalent
++  // uint32_t array instead of a UTF-32 string literal.
++  constexpr uint32_t thresholds[] = {0x9999999au, 0x828f5c29u, 0x80418938u,
++                                     0x80068db9u, 0x8000a7c6u, 0x800010c7u,
++                                     0x800001aeu, 0x8000002bu};
++  return thresholds[index];
++#else
+   return U"\x9999999a\x828f5c29\x80418938\x80068db9\x8000a7c6\x800010c7"
+          U"\x800001ae\x8000002b"[index];
++#endif
+ }
+ 
+ template <typename Float>

--- a/cmake/recipes/eigen.cmake
+++ b/cmake/recipes/eigen.cmake
@@ -6,7 +6,6 @@ endif()
 
 option(EIGEN_WITH_MKL "Use Eigen with MKL" OFF)
 option(EIGEN_DONT_VECTORIZE "Disable Eigen vectorization" OFF)
-option(EIGEN_MPL2_ONLY "Enable Eigen MPL2 license only" OFF)
 
 message(STATUS "Third-party: creating target 'Eigen3::Eigen'")
 
@@ -14,7 +13,7 @@ include(CPM)
 CPMAddPackage(
     NAME eigen
     GITLAB_REPOSITORY libeigen/eigen
-    GIT_TAG 3.4.0
+    GIT_TAG 5.0.1
     DOWNLOAD_ONLY YES
 )
 
@@ -27,12 +26,8 @@ target_include_directories(Eigen3_Eigen SYSTEM INTERFACE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-if(EIGEN_MPL2_ONLY)
-  target_compile_definitions(Eigen3_Eigen INTERFACE EIGEN_MPL2_ONLY)
-endif()
-
 if(EIGEN_DONT_VECTORIZE)
-  target_compile_definitions(Eigen3_Eigen INTERFACE EIGEN_DONT_VECTORIZE)
+    target_compile_definitions(Eigen3_Eigen INTERFACE EIGEN_DONT_VECTORIZE=1)
 endif()
 
 if(EIGEN_WITH_MKL)

--- a/cmake/recipes/libigl.cmake
+++ b/cmake/recipes/libigl.cmake
@@ -9,4 +9,4 @@ message(STATUS "Third-party: creating target 'igl::core'")
 include(eigen)
 
 include(CPM)
-CPMAddPackage("gh:libigl/libigl#89267b4a80b1904de3f6f2812a2053e5e9332b7e")
+CPMAddPackage("gh:libigl/libigl@2.6.0")

--- a/cmake/recipes/onetbb.cmake
+++ b/cmake/recipes/onetbb.cmake
@@ -53,7 +53,7 @@ function(onetbb_import_target)
 
     set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME tbb)
     include(CPM)
-    CPMAddPackage("gh:uxlfoundation/oneTBB@2022.1.0")
+    CPMAddPackage("gh:uxlfoundation/oneTBB@2022.3.0")
 
     pop_variable(BUILD_SHARED_LIBS)
 endfunction()

--- a/cmake/recipes/spdlog.cmake
+++ b/cmake/recipes/spdlog.cmake
@@ -10,7 +10,14 @@ option(SPDLOG_INSTALL "Generate the install target" ON)
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "spdlog")
 
 include(CPM)
-CPMAddPackage("gh:gabime/spdlog@1.15.3")
+# The bundled fmt trips up NVCC's device front-end (EDG): a compile-time /utf-8
+# probe misfires and a char32_t table uses hex escapes with the high bit set.
+# Neither is fixable via compiler flags (the front-end never sees /utf-8), so we
+# patch the bundled headers to guard both cases behind __CUDACC__.
+CPMAddPackage(
+    URI "gh:gabime/spdlog@1.17.0"
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/../patches/fmt-nvcc-compat.patch"
+)
 
 set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/cmake/scalable_ccd/scalable_ccd_use_colors.cmake
+++ b/cmake/scalable_ccd/scalable_ccd_use_colors.cmake
@@ -13,22 +13,11 @@ include_guard(GLOBAL)
 
 # options
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  # Reduce the warning level of external files to the selected value (W1 - only major).
-  # Requires Visual Studio 2017 version 15.7
-  # https://blogs.msdn.microsoft.com/vcblog/2017/12/13/broken-warnings-theory/
-
-  # There is an issue in using these flags in earlier versions of MSVC:
-  # https://developercommunity.visualstudio.com/content/problem/220812/experimentalexternal-generates-a-lot-of-c4193-warn.html
-  if(MSVC_VERSION GREATER 1920)
-      add_compile_options(/experimental:external)
-      add_compile_options(/external:W1)
-  endif()
-
   # When building in parallel, MSVC sometimes fails with the following error:
   # > fatal error C1090: PDB API call failed, error code '23'
   # To avoid this problem, we force PDB write to be synchronous with /FS.
   # https://developercommunity.visualstudio.com/content/problem/48897/c1090-pdb-api-call-failed-error-code-23.html
-  add_compile_options(/FS)
+  add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:/FS>")
 else()
   include(scalable_ccd_filter_flags)
   set(SCALABLE_CCD_GLOBAL_FLAGS

--- a/cmake/scalable_ccd/scalable_ccd_use_colors.cmake
+++ b/cmake/scalable_ccd/scalable_ccd_use_colors.cmake
@@ -17,7 +17,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # > fatal error C1090: PDB API call failed, error code '23'
   # To avoid this problem, we force PDB write to be synchronous with /FS.
   # https://developercommunity.visualstudio.com/content/problem/48897/c1090-pdb-api-call-failed-error-code-23.html
-  add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:/FS>")
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:/FS> $<$<COMPILE_LANGUAGE:CXX>:/FS>)
 else()
   include(scalable_ccd_filter_flags)
   set(SCALABLE_CCD_GLOBAL_FLAGS

--- a/src/scalable_ccd/cuda/broad_phase/utils.cu
+++ b/src/scalable_ccd/cuda/broad_phase/utils.cu
@@ -22,7 +22,7 @@ void setup(
 
     if (!boxes_per_thread) {
         boxes_per_thread =
-            std::max(max_shared_memory / sizeof(AABB) / max_threads, 1ul);
+            std::max(max_shared_memory / sizeof(AABB) / max_threads, size_t(1));
     }
     logger().trace("Boxes per thread: {:d}", boxes_per_thread);
 


### PR DESCRIPTION
Get the project building with MSVC (VS 18 / cl 14.51) and CUDA 13.3:

- Patch spdlog's bundled fmt for NVCC: its device front-end (EDG) never sees the host /utf-8 flag, so fmt's compile-time UTF-8 probe misfires, and EDG rejects the char32_t rounding-threshold table (hex escapes with the high bit set). Guard both behind __CUDACC__ via CPM PATCHES (cmake/patches/fmt-nvcc-compat.patch).
- Forward /utf-8 and /Zc:preprocessor to the CUDA host compiler; CCCL (thrust/cub) requires the conforming preprocessor. CXX gets /utf-8 transitively from spdlog's PUBLIC export.
- Fix a Win64 std::max type mismatch in cuda/broad_phase/utils.cu (unsigned long is 32-bit on Windows): use size_t(1).

Dependency bumps: spdlog 1.15.3 -> 1.17.0, Eigen -> 5.0.1, libigl -> 2.6.0, oneTBB 2022.1.0 -> 2022.3.0.

Also add CMakePresets.json, ignore *.vs, and stop leaking /FS to NVCC.